### PR TITLE
Install newest version of docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ USER root
 RUN apt-get update
 RUN apt-get install -y apt-transport-https ca-certificates curl sudo
 RUN curl -sSL https://get.docker.com/ | sh
-RUN apt-get install -y docker-compose
+
+RUN curl -L https://github.com/docker/compose/releases/download/1.20.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+RUN chmod +x /usr/local/bin/docker-compose
 
 RUN echo "jenkins ALL=NOPASSWD: ALL" >> /etc/sudoers
 


### PR DESCRIPTION
The docker-compose version installed by `apt-get install` it to old to use docker-compose ver. 3 files.
This installation allows to use the newest docker-compose file version.